### PR TITLE
Create docker image with calico_mesos v0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,15 @@ BUILD_DIR=build_calico_mesos
 PYCALICO=$(wildcard $(BUILD_DIR)/libcalico/calico_containers/pycalico/*.py)
 CALICO_MESOS=$(wildcard $(SRCDIR)/calico_mesos.py)
 
-binary: dist/calico_isolator
+binary: dist/calico_mesos
 
-# Create the image that builds calico_isolator
+# Create the image that builds calico_mesos
 calico_mesos_builder.created: $(BUILD_DIR) $(PYCALICO)
 	cd build_calico_mesos; docker build -t calico/mesos-builder .
 	touch calico_mesos_builder.created
 
-
 # Create the binary: check code changes to source code, ensure builder is created.
-dist/calico_isolator: $(CALICO_MESOS) calico_mesos_builder.created
+dist/calico_mesos: $(CALICO_MESOS) calico_mesos_builder.created
 	mkdir -p dist
 	chmod 777 `pwd`/dist
 	
@@ -34,6 +33,13 @@ run-etcd:
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:4001" \
 	--listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
 
+mesos_calico_image.created:
+	docker build -f ./Dockerfile -t calico/mesos-calico .
+	touch mesos_calico_image.created
+
+mesos-calico.tar: mesos_calico_image.created
+	docker save --output mesos-calico.tar calico/mesos-calico
+
 ut: calico_mesos_builder.created
 	# Use the `root` user, since code coverage requires the /code directory to
 	# be writable.  It may not be writable for the `user` account inside the
@@ -43,7 +49,7 @@ ut: calico_mesos_builder.created
 	'/tmp/etcd -data-dir=/tmp/default.etcd/ >/dev/null 2>&1 & \
 	nosetests tests/unit  -c nose.cfg'
 
-ut-circle: calico_mesos_builder.created dist/calico_isolator
+ut-circle: calico_mesos_builder.created dist/calico_mesos
 	docker run \
 	-v `pwd`/calico_mesos:/code \
 	-v $(CIRCLE_TEST_REPORTS):/circle_output \
@@ -54,3 +60,11 @@ ut-circle: calico_mesos_builder.created dist/calico_isolator
 	--with-xunit --xunit-file=/circle_output/output.xml; RC=$$?;\
 	[[ ! -z "$$COVERALLS_REPO_TOKEN" ]] && coveralls || true; exit $$RC'
 
+clean:
+	-rm -f *.created
+	find . -name '*.pyc' -exec rm -f {} +
+	-rm -rf dist
+	-rm -f mesos-calico.tar
+	-docker rmi calico/mesos-calico
+	-docker rmi calico/mesos-builder
+	-docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -93,9 +93,9 @@ Pull the Docker images.  This will take a few minutes.
 
     $ sudo docker pull jplock/zookeeper:3.4.5
     $ sudo docker pull quay.io/coreos/etcd:v2.2.0
-    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
+    $ sudo docker pull calico/mesos-calico
     $ sudo docker pull mesosphere/marathon:v0.9.1
-    $ sudo docker pull calico/node:v0.7.0
+    $ sudo docker pull calico/node:v0.8.0
 
 Next, download the unit files
 
@@ -141,8 +141,8 @@ Do this for each compute host you'll use in your Mesos cluster.
 
 Pull the Docker images.  This will take a few minutes.
 
-    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
-    $ sudo docker pull calico/node:v0.7.0
+    $ sudo docker pull calico/mesos-calico
+    $ sudo docker pull calico/node:v0.8.0
 
 Next, download the unit files
 
@@ -152,7 +152,7 @@ Next, download the unit files
 
 `calicoctl` is a small CLI tool to control your Calico network.  It's used to start Calico services on your compute host, as well as inspect and modify Calico configuration.
 
-    $ curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.7.0/calicoctl
+    $ curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.8.0/calicoctl
     $ chmod +x calicoctl
     $ sudo cp calicoctl /usr/bin/
 
@@ -197,7 +197,7 @@ Test Calico network functionality by running our test framework.  On the master 
 This will start a new shell inside the `mesos-master` container.
 
     $ cd /framework
-    $ ./calico_framework.py
+    $ python calico_framework.py
 
 The Calico framework launches a series of tasks on your Mesos cluster to verify network connectivity and network isolation are working correctly.
 

--- a/docs/units/mesos-agent.service
+++ b/docs/units/mesos-agent.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/docker run --name mesos-agent \
   -e ETCD_AUTHORITY=${ETCD_AUTHORITY} \
   --net host \
   --privileged \
-  spikecurtis/mesos-calico:0.25.0-rc2 /root/runagent
+  calico/mesos-calico /root/runagent
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/units/mesos-master.service
+++ b/docs/units/mesos-master.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/docker run --name mesos-master \
   -e MESOS_QUORUM=1 \
   -e MESOS_LOG_DIR=/var/log \
   --net host \
-  spikecurtis/mesos-calico:0.25.0-rc2 /usr/local/sbin/mesos-master
+  calico/mesos-calico /usr/local/sbin/mesos-master
 
 [Install]
 WantedBy=multi-user.target

--- a/image/base.sh
+++ b/image/base.sh
@@ -26,4 +26,5 @@ $minimal_apt_get_install \
   libsasl2-dev                     \
   libgoogle-glog-dev               \
   libboost-dev                     \
-  libprotobuf-dev
+  libprotobuf-dev                  \
+  wget

--- a/image/install.sh
+++ b/image/install.sh
@@ -63,8 +63,8 @@ cp /mesos/build/bin/*.sh /root
 
 # Isolator
 mkdir -p /net-modules
-git clone https://github.com/djosborne/net-modules.git /net-modules
-cd /net-modules && git checkout 0.25-framework
+git clone https://github.com/mesosphere/net-modules.git /net-modules
+cd /net-modules && git checkout integration/0.25
 mv /net-modules/isolator /
 cd /isolator
 
@@ -79,5 +79,7 @@ cd /isolator
 mv /build/runagent /root
 mkdir /calico
 mv /net-modules/calico/modules.json /calico/
-mv /net-modules/calico/calico_isolator /calico/
+cd /calico
+wget https://github.com/projectcalico/calico-mesos/releases/download/v0.1.1/calico_mesos
+chmod +x calico_mesos
 mv /net-modules/framework /


### PR DESCRIPTION
Spike's previous docker image was running a bugged version of the calico_mesos plugin. Need to create a new Docker image with correct version.

Bump up calicoctl version to v0.8.0 to match calico_mesos v0.1.1 dependencies.

Also includes Makefile changes to build the Docker image.
